### PR TITLE
feat: add leave types function

### DIFF
--- a/backendApi/app/Http/Controllers/LeaveTypeController.php
+++ b/backendApi/app/Http/Controllers/LeaveTypeController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Models\LeaveType;
+
+class LeaveTypeController extends Controller
+{
+    /**
+     * 1️⃣ 新增請假類型
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100|unique:leave_types,name',  // 英文名稱
+            'description' => 'required|string|max:255',                   // 中文名稱
+            'total_hours' => 'nullable|integer|min:0',                    // 時數
+        ]);
+
+        $leaveType = LeaveType::create($validated);
+
+        return response()->json([
+            'message' => '假別新增成功',
+            'leave_type' => $leaveType,
+        ], 201);
+    }
+
+    /**
+     * 2️⃣ 修改請假類型
+     */
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $leaveType = LeaveType::find($id);
+
+        if (!$leaveType) {
+            return response()->json(['message' => '找不到該請假類型'], 404);
+        }
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:100|unique:leave_types,name,' . $id,
+            'description' => 'required|string|max:255',
+            'total_hours' => 'nullable|integer|min:0',
+        ]);
+
+        $leaveType->update($validated);
+
+        return response()->json([
+            'message' => '假別更新成功',
+            'leave_type' => $leaveType,
+        ], 200);
+    }
+
+    /**
+     * 3️⃣ 刪除請假類型
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $leaveType = LeaveType::find($id);
+
+        if (!$leaveType) {
+            return response()->json(['message' => '找不到該請假類型'], 404);
+        }
+
+        $leaveType->delete();
+
+        return response()->json(['message' => '假別刪除成功'], 200);
+    }
+
+    /**
+     * 4️⃣ 取得所有請假類型（放在下拉式選單）
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(LeaveType::all());
+    }
+}

--- a/backendApi/app/Models/LeaveType.php
+++ b/backendApi/app/Models/LeaveType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Leave;
+use App\Models\LeaveResetRule;
+
+
+class LeaveType extends Model
+{
+    use HasFactory;
+
+    // 新增假別表
+    protected $fillable = ['name', 'description', 'total_hours'];
+
+    // 定義和 leaves 表的關聯（假設 leaves 有 leave_type_id）
+    public function leaves()
+    {
+        return $this->hasMany(Leave::class, 'leave_type_id');
+    }
+
+    public function resetRules()
+{
+    return $this->hasMany(LeaveResetRule::class);
+}
+}
+

--- a/backendApi/database/migrations/2025_03_10_145029_create_leave_types_table.php
+++ b/backendApi/database/migrations/2025_03_10_145029_create_leave_types_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('leave_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->unique(); // 填入假別中文
+            $table->integer('total_hours')->nullable(); // 每年總可用小時數
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('leave_types');
+    }
+};


### PR DESCRIPTION
-- feat leave types migration
-- feat leave types table
-- feat leave types controller:
1. add leave types store function (create)
2. add leave types update function(update)
3.  add leave types destroy function (delete)
4. add leave types index function (get all)

※ **I have not added the routes yet, and these routes require Admin permissions.**
```
Route::middleware('auth:api')->prefix('leavetypes')->group(function () {
    // 1. Add Leave Type API
    Route::post('/add', [LeaveTypeController::class, 'store']);
    
    // 2. Update Leave Type API
    Route::put('/update/{id}', [LeaveTypeController::class, 'update']);
    
    // 3. Delete Leave Type API
    Route::delete('/{id}', [LeaveTypeController::class, 'destroy']);
    
    // 4. Leave Type Dropdown API (For dropdown selection)
    Route::get('/', [LeaveTypeController::class, 'index']);
});
```
