### PR TITLE
fix: update authAtom

### DIFF
--- a/frontend/src/state/authAtom.js
+++ b/frontend/src/state/authAtom.js
@@ -1,13 +1,31 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 
-// 管理登入狀態 (儲存在 localStorage)
-export const authAtom = atomWithStorage("auth", {
-  access_token: null, // JWT Token
-  user: null,
-});
+/**
+ * 初始化認證狀態。
+ * 從 localStorage 中獲取存儲的認證資訊。
+ * 如果存儲的數據無效或不存在，則回傳一個預設的認證狀態對象。
+ *
+ * @returns {Object} 認證狀態對象。
+ * @property {string|null} access_token - 訪問令牌，若無則為 null。
+ * @property {Object|null} user - 用戶對象，若無則為 null。
+ */
+const initialAuth = () => {
+  try {
+    return JSON.parse(localStorage.getItem("auth")) || { access_token: null, user: null };
+  } catch {
+    return { access_token: null, user: null };
+  }
+};
 
-// ✅ 讓 `isAuthenticatedAtom` 依賴 `authAtom` 的 `access_token`
+// ✅ 使用 `atomWithStorage` 來初始化 `authAtom`，並將其存儲於 localStorage
+export const authAtom = atomWithStorage("auth", initialAuth());
+
+/**
+ * `isAuthenticatedAtom`：基於 `authAtom` 的 `access_token` 來判斷用戶是否已登入。
+ *
+ * @returns {boolean} 如果 `access_token` 存在則回傳 `true`，否則回傳 `false`。
+ */
 export const isAuthenticatedAtom = atom(
-  (get) => !!get(authAtom).access_token // 有 Token 就視為已登入
+  (get) => !!get(authAtom).access_token // 若有 Token，則視為已登入
 );


### PR DESCRIPTION
1. Initialize the authentication state.
2. Get the stored authentication information from localStorage.
3. If the stored data is invalid or does not exist, a preset authentication status object is returned.
4. Use `atomWithStorage` to initialize `authAtom` and store it in localStorage