### PR TITLE
fix: update protectedroute

### DIFF
--- a/frontend/src/components/protectedRoute.jsx
+++ b/frontend/src/components/protectedRoute.jsx
@@ -1,6 +1,8 @@
 import { Navigate } from "react-router-dom"; // 用來做頁面導向 (重定向)
-import { useAtom } from "jotai"; // 從 Jotai 引入 `useAtom`，用來讀取 `authAtom`
-import { authAtom } from "../state/authAtom"; // 引入 `authAtom`，用來獲取登入狀態
+import { useAtomValue } from "jotai"; // 改用 `useAtomValue`，避免不必要的 re-render
+import { isAuthenticatedAtom } from "../state/authAtom"; // 改用 `isAuthenticatedAtom`，不直接讀取 `authAtom`
+
+import PropTypes from "prop-types";
 
 /**
  * `ProtectedRoute` 是一個保護頁面的元件
@@ -12,18 +14,8 @@ import { authAtom } from "../state/authAtom"; // 引入 `authAtom`，用來獲�
  * @returns {JSX.Element} - 若已登入，顯示 `children`，否則跳轉到 `/login`
  */
 const ProtectedRoute = ({ children }) => {
-  
-  // 透過 `useAtom` 讀取 `authAtom`，獲取當前的登入資訊
-  const [auth] = useAtom(authAtom);
-
-  /**
-   * 判斷使用者是否已經登入
-   * 1. `auth?.access_token`：如果 `authAtom` 裡面有 `access_token`，代表已登入
-   * 2. `localStorage.getItem("auth")`：如果 `localStorage` 有存 `auth`，代表登入狀態持久化
-   * 3. `!!` 用來轉換為布林值，確保 `true` / `false`
-   */
-  const isAuthenticated = !!auth?.access_token || !!localStorage.getItem("auth");
-  // console.log(isAuthenticated);
+  // ✅ 改用 `isAuthenticatedAtom` 來判斷是否登入，避免 `localStorage` 操作
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
 
   /**
    * 根據登入狀態決定要顯示什麼：
@@ -31,6 +23,11 @@ const ProtectedRoute = ({ children }) => {
    * - ❌ 如果未登入 (isAuthenticated 為 false)，導向 `/login` (透過 `<Navigate to="/login" replace />`)
    */
   return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+// ✅ PropTypes 檢查，確保 `children` 傳入的是有效的 React 元件
+ProtectedRoute.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 export default ProtectedRoute; // 匯出元件，讓其他頁面使用


### PR DESCRIPTION
1. Use `useAtomValue` to avoid unnecessary re-rendering
2. Use `isAuthenticatedAtom` instead of reading `authAtom` directly
3. Use `isAuthenticatedAtom` to determine whether to log in and avoid `localStorage` operations
4. PropTypes check to ensure that `children` passes in valid React components